### PR TITLE
collision with Bootstrap Dropdowns

### DIFF
--- a/src/socialshare.js
+++ b/src/socialshare.js
@@ -4,12 +4,12 @@
 
     /* DROPDOWN CLASS DEFINITION */
 
-    var toggle = '[data-toggle="dropdown"]';
+    var toggle = '[data-toggle="socialshare"]';
     var share_selector = '.socialshare';
     var fb_iframe = '.socialshare.open[data-type="small-bubbles"] .share-options div.fb-like iframe';
     var $share_container;
     var packaged_html = '' +
-    '<div class="dropdown-toggle" data-toggle="dropdown">' +
+    '<div class="dropdown-toggle" data-toggle="socialshare">' +
     '    <div class="share-link"><div>' +
     '        <div class="heart"></div>' +
     '        <p class="text">Share This</p>' +


### PR DESCRIPTION
We'd love to use SocialShare in [mozilla/openbadges](https://github.com/mozilla/openbadges) but it collides with the Bootstrap dropdowns plugin. With both on the page, a single click fires both the SocialShare and Bootstrap toggles, opening and immediately closing the share menu. 

Changing the `data-toggle` attribute value means Bootstrap won't install its handler, and things work fine. 
