### PR TITLE
add line-height and font-size to css

### DIFF
--- a/src/style.less
+++ b/src/style.less
@@ -75,6 +75,8 @@
 
         .text {
             border-bottom: 1px dotted rgba(72, 72, 72, 0.4);
+            font-size: 16px;
+            line-height: 24px;
             letter-spacing: -0.25px;
             float: left;
             margin: 0;


### PR DESCRIPTION
Since having the proper font size and line height are required to get the "Share This" text to line up with the heart and caret, I thought it made sense to add it to the SocialShare css instead of declaring it externally. 
